### PR TITLE
Feat/checkcycles

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -69,6 +69,18 @@ class DAG(nx.DiGraph):
 
     def __init__(self, ebunch=None):
         super(DAG, self).__init__(ebunch)
+        cycles = []
+        try:
+            cycles = list(nx.find_cycle(self))
+        except nx.NetworkXNoCycle:
+            pass
+        else:
+            out_str =  'Cycles are not allowed in a DAG.'
+            out_str += '\nEdges indicating the path taken for a loop: '
+            out_str += ''.join(['({0},{1}) '.format(u, v) for (u,v) in cycles])
+            raise ValueError(out_str)
+
+
 
     def add_node(self, node, weight=None):
         """

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -123,6 +123,12 @@ class TestDAGCreation(unittest.TestCase):
         self.graph.add_edge('H', 'G')
         self.assertEqual(sorted(['A', 'H']), sorted(self.graph.get_roots()))
 
+    def test_init_with_cycle(self):
+        self.assertRaises(ValueError, DAG, [('a', 'a')])
+        self.assertRaises(ValueError, DAG, [('a', 'b'), ('b', 'a')])
+        self.assertRaises(ValueError, DAG, [('a', 'b'), ('b', 'c'),
+                                           ('c', 'a')])
+
     def tearDown(self):
         del self.graph
 

--- a/pgmpy/tests/test_estimators/test_ConstraintBasedEstimator.py
+++ b/pgmpy/tests/test_estimators/test_ConstraintBasedEstimator.py
@@ -2,6 +2,7 @@ import unittest
 
 import pandas as pd
 import numpy as np
+import networkx as nx
 
 from pgmpy.estimators import ConstraintBasedEstimator
 from pgmpy.independencies import Independencies
@@ -54,18 +55,18 @@ class TestConstraintBasedEstimator(unittest.TestCase):
                             set([('A', 'B'), ('B', 'A'), ('A', 'C'), ('C', 'A')]))
 
     def test_pdag_to_dag(self):
-        pdag1 = DAG([('A', 'B'), ('C', 'B'), ('C', 'D'), ('D', 'C'), ('D', 'A'), ('A', 'D')])
+        pdag1 = nx.DiGraph([('A', 'B'), ('C', 'B'), ('C', 'D'), ('D', 'C'), ('D', 'A'), ('A', 'D')])
         dag1 = ConstraintBasedEstimator.pdag_to_dag(pdag1)
         self.assertTrue(('A', 'B') in dag1.edges() and
                         ('C', 'B') in dag1.edges() and
                         len(dag1.edges()) == 4)
 
-        pdag2 = DAG([('B', 'C'), ('D', 'A'), ('A', 'D'), ('A', 'C')])
+        pdag2 = nx.DiGraph([('B', 'C'), ('D', 'A'), ('A', 'D'), ('A', 'C')])
         dag2 = ConstraintBasedEstimator.pdag_to_dag(pdag2)
         self.assertTrue(set(dag2.edges()) == set([('B', 'C'), ('A', 'D'), ('A', 'C')]) or
                         set(dag2.edges()) == set([('B', 'C'), ('D', 'A'), ('A', 'C')]))
 
-        pdag3 = DAG([('B', 'C'), ('D', 'C'), ('C', 'D'), ('A', 'C')])
+        pdag3 = nx.DiGraph([('B', 'C'), ('D', 'C'), ('C', 'D'), ('A', 'C')])
         dag3 = ConstraintBasedEstimator.pdag_to_dag(pdag3)
         self.assertSetEqual(set([('B', 'C'), ('C', 'D'), ('A', 'C')]),
                             set(dag3.edges()))


### PR DESCRIPTION
### Fixes
#2
#### Changes
- Test for pdag_to_dag, uses a networkx.DiGraph instead of a DAG because a DAG cannot be a PDAG.
- DAG.__init__ raises an exception if it contains cycles